### PR TITLE
Version bumps. Fix in pom.xml

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,9 +1,9 @@
 name=akka-grpc-quickstart-java
 description = Akka gRPC is a toolkit for building streaming gRPC servers and clients on top of Akka Streams. This simple application will get you started building gRPC based systems with Java. This app uses Akka, Java, and ScalaTest.
-akka_grpc_version=maven(com.lightbend.akka.grpc, akka-grpc-runtime_2.12, stable)
-akka_version=maven(com.typesafe.akka, akka-actor_2.12, stable)
+akka_grpc_version=maven(com.lightbend.akka.grpc, akka-grpc-runtime_2.13, stable)
+akka_version=maven(com.typesafe.akka, akka-actor_2.13, stable)
 sbt_version=maven(org.scala-sbt, sbt)
 jetty_alpn_agent_version=maven(org.mortbay.jetty.alpn, jetty-alpn-agent, stable)
-scala_major_version=2.12
-scala_version=2.12.11
+scala_major_version=2.13
+scala_version=2.13.2
 verbatim=*.scala *.conf *.proto *.pem *.key gradlew gradlew.bat gradle-wrapper.properties gradle-wrapper.jar

--- a/src/main/g8/pom.xml
+++ b/src/main/g8/pom.xml
@@ -31,7 +31,7 @@
     <akka.grpc.version>$akka_grpc_version$</akka.grpc.version>
     <scala.binary.version>$scala_major_version$</scala.binary.version>
     <jetty.alpn.agent.version>$jetty_alpn_agent_version$</jetty.alpn.agent.version>
-    <grpc.version>1.13.1</grpc.version>
+    <grpc.version>1.28.1</grpc.version>
     <project.encoding>UTF-8</project.encoding>
   </properties>
 
@@ -66,8 +66,8 @@
     <dependency>
       <groupId>org.mortbay.jetty.alpn</groupId>
       <artifactId>jetty-alpn-agent</artifactId>
-      <version>2.0.10</version>
-      <scope>\${jetty.alpn.agent.version}</scope>
+      <version>\${jetty.alpn.agent.version}</version>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Default to scala 2.13.

Align `grpc.version` in `pom.xml`. Fix version/scope values for Jetty agent in `pom.xml`

NOTE: I'm purposedly not bumping any dependency on the project itself and focusing this PR on the generated code only.