### PR TITLE
Updates code to Akka HTTP 10.2.3

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.3.13

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -4,5 +4,5 @@ akka_grpc_version=maven(com.lightbend.akka.grpc, akka-grpc-runtime_2.13, stable)
 akka_version=maven(com.typesafe.akka, akka-actor_2.13, stable)
 sbt_version=maven(org.scala-sbt, sbt, stable)
 scala_major_version=2.13
-scala_version=2.13.2
+scala_version=2.13.4
 verbatim=*.java *.conf *.proto *.pem *.key gradlew gradlew.bat gradle-wrapper.properties gradle-wrapper.jar

--- a/src/main/g8/src/main/java/com/example/helloworld/GreeterServer.java
+++ b/src/main/g8/src/main/java/com/example/helloworld/GreeterServer.java
@@ -3,13 +3,11 @@ package com.example.helloworld;
 //#import
 
 import akka.actor.typed.ActorSystem;
-import akka.actor.typed.javadsl.Adapter;
 import akka.actor.typed.javadsl.Behaviors;
 import akka.http.javadsl.*;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
-import akka.japi.Function;
-import akka.stream.SystemMaterializer;
+import akka.japi.function.Function;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
@@ -27,7 +25,6 @@ import java.security.cert.CertificateFactory;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
 import java.util.concurrent.CompletionStage;
-
 
 //#import
 
@@ -56,13 +53,10 @@ public class GreeterServer {
             system);
 
     CompletionStage<ServerBinding> bound =
-        // Akka HTTP 10.1 requires adapters to accept the new actors APIs
-        Http.get(Adapter.toClassic(system)).bindAndHandleAsync(
-          service,
-          ConnectWithHttps.toHostHttps("127.0.0.1", 8080)
-              .withCustomHttpsContext(serverHttpContext()),
-          SystemMaterializer.get(system).materializer()
-        );
+            Http.get(system)
+                    .newServerAt("127.0.0.1", 8080)
+                    .enableHttps(serverHttpContext())
+                    .bind(service);
 
     bound.thenAccept(binding ->
         System.out.println("gRPC server bound to: " + binding.localAddress())


### PR DESCRIPTION
Some fixes required for users accepting default. With Akka gRPC 1.1.0 out, the generated code has compilation errors (invalud import akka.japi.Function) and deprecated APi usage.